### PR TITLE
Add support for Symfony ^3.4 as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/http-kernel": "^4.0",
-        "symfony/dependency-injection": "^4.0",
-        "symfony/config": "^4.0",
-        "symfony/form": "^4.0"
+        "symfony/http-kernel": "^3.4|^4.0",
+        "symfony/dependency-injection": "^3.4|^4.0",
+        "symfony/config": "^3.4|^4.0",
+        "symfony/form": "^3.4|^4.0"
     },
     "require-dev": {
-        "symfony/phpunit-bridge": "^3.3|^4.0"
+        "symfony/phpunit-bridge": "^3.4|^4.0"
     },
     "autoload": {
         "psr-4": { "Becklyn\\OrderedFormBundle\\": "" }


### PR DESCRIPTION
To ease the upgrade path from Symfony 3.x to 4.x, we should also add support for 3.x.