### PR TITLE
fix Deprecation warning on Symfony 4.2

### DIFF
--- a/Form/Extension/ButtonPositionExtension.php
+++ b/Form/Extension/ButtonPositionExtension.php
@@ -13,6 +13,14 @@ class ButtonPositionExtension extends FormPositionExtension
      */
     public function getExtendedType ()
     {
-        return ButtonType::class;
+        return self::getExtendedTypes()[0];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getExtendedTypes ()
+    {
+        return [ FormType::class ];
     }
 }

--- a/Form/Extension/FormPositionExtension.php
+++ b/Form/Extension/FormPositionExtension.php
@@ -27,6 +27,14 @@ class FormPositionExtension extends AbstractTypeExtension
      */
     public function getExtendedType ()
     {
-        return FormType::class;
+        return self::getExtendedTypes()[0];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getExtendedTypes ()
+    {
+        return [ FormType::class ];
     }
 }


### PR DESCRIPTION
fix Not implementing the static getExtendedTypes() method deprecation warning on Symfony 4.2