### PR TITLE
Add php8 version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/form": "^4.4 || ^5.0",


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | yes                 |
| Improvement?  | yes    |
| BC breaks?    | yes                                                                |
| Deprecations? | yes    |
| Docs PR       | **missing**                                  |

<!-- describe your changes below -->
Juste allowing the bundle to be installed with php 8