### PR TITLE
Klapaudius patch deprecation warning s5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+1.2.2
+=====
+
+*   (improvement) Remove Symfony 5.4 deprecation warnings
+
+
+1.2.1
+=====
+
+*   (improvement) Add initial support for PHP 8.
+
+
 1.2.0
 =====
 

--- a/src/Form/ResolvedType/OrderedResolvedFormTypeFactory.php
+++ b/src/Form/ResolvedType/OrderedResolvedFormTypeFactory.php
@@ -15,7 +15,7 @@ class OrderedResolvedFormTypeFactory implements ResolvedFormTypeFactoryInterface
         FormTypeInterface $type,
         array $typeExtensions,
         ?ResolvedFormTypeInterface $parent = null
-    )
+    ): ResolvedFormTypeInterface
     {
         return new OrderedResolvedFormType($type, $typeExtensions, $parent);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| Bug fix?      | no                                                                |
| New feature?  | no                   |
| Improvement?  | yes     |
| BC breaks?    | no                                                                |
| Deprecations? | no    |
| Docs PR       |                                   |

<!-- describe your changes below -->
Add ResolvedFormTypeInterface as the native return type on Becklyn\OrderedFormBundle\Form\ResolvedType\OrderedResolvedFormTypeFactory::createResolvedType 
to fix deprecation warnings